### PR TITLE
Fix hourly update timing

### DIFF
--- a/custom_components/pstryk/coordinator.py
+++ b/custom_components/pstryk/coordinator.py
@@ -82,6 +82,10 @@ class PstrykDataUpdateCoordinator(DataUpdateCoordinator):
                     sell_data["prices"].extend(future_sell_data.get("prices", []))
                     sell_data["has_future_data"] = True
 
+            # Dynamically adjust the next update to align with the top of the hour
+            next_hour = now_utc.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+            self.update_interval = next_hour - now_utc
+
             return {
                 "buy": buy_data,
                 "sell": sell_data,


### PR DESCRIPTION
## Summary
- ensure hourly data refresh happens at the top of each hour

## Testing
- `flake8` *(fails: command not found)*