### PR TITLE
🆕 Add Real Energy Usage and Cost Sensors

### DIFF
--- a/custom_components/pstryk/const.py
+++ b/custom_components/pstryk/const.py
@@ -5,6 +5,8 @@ DOMAIN = "pstryk"
 API_BASE_URL = "https://api.pstryk.pl/integrations"
 BUY_ENDPOINT = "pricing/?resolution=hour&window_start={start}&window_end={end}"
 SELL_ENDPOINT = "prosumer-pricing/?resolution=hour&window_start={start}&window_end={end}"
+ENERGY_COST_ENDPOINT = "meter-data/energy-cost/?resolution=hour&window_start={start}&window_end={end}"
+ENERGY_USAGE_ENDPOINT = "meter-data/energy-usage/?resolution=hour&window_start={start}&window_end={end}"
 
 CONF_API_TOKEN = "api_token"
 
@@ -20,5 +22,7 @@ ATTR_IS_EXPENSIVE = "is_expensive"
 ATTR_CHEAP_HOURS = "cheap_hours"
 ATTR_EXPENSIVE_HOURS = "expensive_hours"
 ATTR_PRICES_FUTURE = "prices_future"
+ATTR_CURRENT_ENERGY_COST = "current_energy_cost"
+ATTR_PREVIOUS_HOUR_ENERGY_COST = "previous_hour_energy_cost"
 
 COORDINATOR = "coordinator"

--- a/custom_components/pstryk/sensor.py
+++ b/custom_components/pstryk/sensor.py
@@ -57,6 +57,30 @@ async def async_setup_entry(
         # Energy usage sensors for previous full hour
         PstrykBuyEnergyUsageSensor(coordinator),
         PstrykSellEnergyProductionSensor(coordinator),
+        # Energy cost sensors for yesterday
+        PstrykBuyEnergyCostYesterdaySensor(coordinator),
+        PstrykSellEnergyCostYesterdaySensor(coordinator),
+        # Energy usage sensors for yesterday  
+        PstrykBuyEnergyUsageYesterdaySensor(coordinator),
+        PstrykSellEnergyProductionYesterdaySensor(coordinator),
+        # Energy cost sensors for previous month
+        PstrykBuyEnergyCostPreviousMonthSensor(coordinator),
+        PstrykSellEnergyCostPreviousMonthSensor(coordinator),
+        # Energy usage sensors for previous month
+        PstrykBuyEnergyUsagePreviousMonthSensor(coordinator),
+        PstrykSellEnergyProductionPreviousMonthSensor(coordinator),
+        # Energy cost sensors for today
+        PstrykBuyEnergyCostTodaySensor(coordinator),
+        PstrykSellEnergyCostTodaySensor(coordinator),
+        # Energy usage sensors for today  
+        PstrykBuyEnergyUsageTodaySensor(coordinator),
+        PstrykSellEnergyProductionTodaySensor(coordinator),
+        # Energy cost sensors for current month
+        PstrykBuyEnergyCostCurrentMonthSensor(coordinator),
+        PstrykSellEnergyCostCurrentMonthSensor(coordinator),
+        # Energy usage sensors for current month
+        PstrykBuyEnergyUsageCurrentMonthSensor(coordinator),
+        PstrykSellEnergyProductionCurrentMonthSensor(coordinator),
     ]
 
     async_add_entities(entities)
@@ -558,5 +582,833 @@ class PstrykSellEnergyProductionSensor(PstrykBaseSensor):
                 "rae": usage_breakdown.get("rae"),
                 "energy_balance": usage_breakdown.get("energy_balance"),
             })
+        
+        return attrs
+
+
+# -----------------------------------------------------------------------------
+# Energy cost and usage sensors for yesterday
+# -----------------------------------------------------------------------------
+
+
+class PstrykBuyEnergyCostYesterdaySensor(PstrykBaseSensor):
+    """Sensor for energy buy cost from yesterday."""
+
+    _attr_name = "Pstryk Buy Energy Cost – Yesterday"
+    _attr_unique_id = "pstryk_energy_cost_buy_yesterday"
+    _attr_icon = "mdi:cash-multiple"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy buy cost for yesterday."""
+        if not self.coordinator.data or "energy_cost_yesterday" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_yesterday"]
+        return energy_cost_data.get("yesterday_cost")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy cost details for yesterday."""
+        if not self.coordinator.data or "energy_cost_yesterday" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_yesterday"]
+        attrs = {}
+        
+        # Add total cost if available
+        if energy_cost_data.get("yesterday_total_cost") is not None:
+            attrs["total_cost"] = energy_cost_data["yesterday_total_cost"]
+        
+        # Add frame count
+        if energy_cost_data.get("yesterday_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["yesterday_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyCostYesterdaySensor(PstrykBaseSensor):
+    """Sensor for energy sell value from yesterday."""
+
+    _attr_name = "Pstryk Sell Energy Cost – Yesterday"
+    _attr_unique_id = "pstryk_energy_cost_sell_yesterday"
+    _attr_icon = "mdi:cash-plus"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy sell value for yesterday."""
+        if not self.coordinator.data or "energy_cost_yesterday" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_yesterday"]
+        return energy_cost_data.get("yesterday_sell_value")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy sell details for yesterday."""
+        if not self.coordinator.data or "energy_cost_yesterday" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_yesterday"]
+        attrs = {}
+        
+        # Add frame count
+        if energy_cost_data.get("yesterday_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["yesterday_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykBuyEnergyUsageYesterdaySensor(PstrykBaseSensor):
+    """Sensor for energy usage from yesterday."""
+
+    _attr_name = "Pstryk Buy Energy Usage – Yesterday"
+    _attr_unique_id = "pstryk_buy_energy_usage_yesterday"
+    _attr_icon = "mdi:flash-auto"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy usage for yesterday."""
+        if not self.coordinator.data or "energy_usage_yesterday" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_yesterday"]
+        return energy_usage_data.get("yesterday_usage")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy usage details for yesterday."""
+        if not self.coordinator.data or "energy_usage_yesterday" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_yesterday"]
+        attrs = {}
+        
+        # Add total usage if available
+        if energy_usage_data.get("yesterday_total_usage") is not None:
+            attrs["total_usage"] = energy_usage_data["yesterday_total_usage"]
+        
+        # Add frame count
+        if energy_usage_data.get("yesterday_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["yesterday_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyProductionYesterdaySensor(PstrykBaseSensor):
+    """Sensor for energy production from yesterday."""
+
+    _attr_name = "Pstryk Sell Energy Production – Yesterday"
+    _attr_unique_id = "pstryk_sell_energy_production_yesterday"
+    _attr_icon = "mdi:solar-power"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy production for yesterday."""
+        if not self.coordinator.data or "energy_usage_yesterday" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_yesterday"]
+        return energy_usage_data.get("yesterday_production")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy production details for yesterday."""
+        if not self.coordinator.data or "energy_usage_yesterday" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_yesterday"]
+        attrs = {}
+        
+        # Add total production if available
+        if energy_usage_data.get("yesterday_total_production") is not None:
+            attrs["total_production"] = energy_usage_data["yesterday_total_production"]
+        
+        # Add frame count
+        if energy_usage_data.get("yesterday_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["yesterday_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+# -----------------------------------------------------------------------------
+# Energy cost and usage sensors for previous month
+# -----------------------------------------------------------------------------
+
+
+class PstrykBuyEnergyCostPreviousMonthSensor(PstrykBaseSensor):
+    """Sensor for energy buy cost from previous month."""
+
+    _attr_name = "Pstryk Buy Energy Cost – Previous Month"
+    _attr_unique_id = "pstryk_energy_cost_buy_previous_month"
+    _attr_icon = "mdi:cash-multiple"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy buy cost for previous month."""
+        if not self.coordinator.data or "energy_cost_previous_month" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_previous_month"]
+        return energy_cost_data.get("previous_month_cost")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy cost details for previous month."""
+        if not self.coordinator.data or "energy_cost_previous_month" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_previous_month"]
+        attrs = {}
+        
+        # Add total cost if available
+        if energy_cost_data.get("previous_month_total_cost") is not None:
+            attrs["total_cost"] = energy_cost_data["previous_month_total_cost"]
+        
+        # Add frame count
+        if energy_cost_data.get("previous_month_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["previous_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyCostPreviousMonthSensor(PstrykBaseSensor):
+    """Sensor for energy sell value from previous month."""
+
+    _attr_name = "Pstryk Sell Energy Cost – Previous Month"
+    _attr_unique_id = "pstryk_energy_cost_sell_previous_month"
+    _attr_icon = "mdi:cash-plus"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy sell value for previous month."""
+        if not self.coordinator.data or "energy_cost_previous_month" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_previous_month"]
+        return energy_cost_data.get("previous_month_sell_value")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy sell details for previous month."""
+        if not self.coordinator.data or "energy_cost_previous_month" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_previous_month"]
+        attrs = {}
+        
+        # Add frame count
+        if energy_cost_data.get("previous_month_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["previous_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykBuyEnergyUsagePreviousMonthSensor(PstrykBaseSensor):
+    """Sensor for energy usage from previous month."""
+
+    _attr_name = "Pstryk Buy Energy Usage – Previous Month"
+    _attr_unique_id = "pstryk_buy_energy_usage_previous_month"
+    _attr_icon = "mdi:flash-auto"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy usage for previous month."""
+        if not self.coordinator.data or "energy_usage_previous_month" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_previous_month"]
+        return energy_usage_data.get("previous_month_usage")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy usage details for previous month."""
+        if not self.coordinator.data or "energy_usage_previous_month" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_previous_month"]
+        attrs = {}
+        
+        # Add total usage if available
+        if energy_usage_data.get("previous_month_total_usage") is not None:
+            attrs["total_usage"] = energy_usage_data["previous_month_total_usage"]
+        
+        # Add frame count
+        if energy_usage_data.get("previous_month_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["previous_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyProductionPreviousMonthSensor(PstrykBaseSensor):
+    """Sensor for energy production from previous month."""
+
+    _attr_name = "Pstryk Sell Energy Production – Previous Month"
+    _attr_unique_id = "pstryk_sell_energy_production_previous_month"
+    _attr_icon = "mdi:solar-power"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy production for previous month."""
+        if not self.coordinator.data or "energy_usage_previous_month" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_previous_month"]
+        return energy_usage_data.get("previous_month_production")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy production details for previous month."""
+        if not self.coordinator.data or "energy_usage_previous_month" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_previous_month"]
+        attrs = {}
+        
+        # Add total production if available
+        if energy_usage_data.get("previous_month_total_production") is not None:
+            attrs["total_production"] = energy_usage_data["previous_month_total_production"]
+        
+        # Add frame count
+        if energy_usage_data.get("previous_month_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["previous_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+# -----------------------------------------------------------------------------
+# Energy cost and usage sensors for today
+# -----------------------------------------------------------------------------
+
+
+class PstrykBuyEnergyCostTodaySensor(PstrykBaseSensor):
+    """Sensor for energy buy cost from today."""
+
+    _attr_name = "Pstryk Buy Energy Cost – Today"
+    _attr_unique_id = "pstryk_energy_cost_buy_today"
+    _attr_icon = "mdi:cash-multiple"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy buy cost for today."""
+        if not self.coordinator.data or "energy_cost_today" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_today"]
+        return energy_cost_data.get("today_cost")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy cost details for today."""
+        if not self.coordinator.data or "energy_cost_today" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_today"]
+        attrs = {}
+        
+        # Add total cost if available
+        if energy_cost_data.get("today_total_cost") is not None:
+            attrs["total_cost"] = energy_cost_data["today_total_cost"]
+        
+        # Add frame count
+        if energy_cost_data.get("today_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["today_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyCostTodaySensor(PstrykBaseSensor):
+    """Sensor for energy sell value from today."""
+
+    _attr_name = "Pstryk Sell Energy Cost – Today"
+    _attr_unique_id = "pstryk_energy_cost_sell_today"
+    _attr_icon = "mdi:cash-plus"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy sell value for today."""
+        if not self.coordinator.data or "energy_cost_today" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_today"]
+        return energy_cost_data.get("today_sell_value")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy sell details for today."""
+        if not self.coordinator.data or "energy_cost_today" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_today"]
+        attrs = {}
+        
+        # Add frame count
+        if energy_cost_data.get("today_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["today_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykBuyEnergyUsageTodaySensor(PstrykBaseSensor):
+    """Sensor for energy usage from today."""
+
+    _attr_name = "Pstryk Buy Energy Usage – Today"
+    _attr_unique_id = "pstryk_buy_energy_usage_today"
+    _attr_icon = "mdi:flash-auto"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy usage for today."""
+        if not self.coordinator.data or "energy_usage_today" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_today"]
+        return energy_usage_data.get("today_usage")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy usage details for today."""
+        if not self.coordinator.data or "energy_usage_today" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_today"]
+        attrs = {}
+        
+        # Add total usage if available
+        if energy_usage_data.get("today_total_usage") is not None:
+            attrs["total_usage"] = energy_usage_data["today_total_usage"]
+        
+        # Add frame count
+        if energy_usage_data.get("today_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["today_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyProductionTodaySensor(PstrykBaseSensor):
+    """Sensor for energy production from today."""
+
+    _attr_name = "Pstryk Sell Energy Production – Today"
+    _attr_unique_id = "pstryk_sell_energy_production_today"
+    _attr_icon = "mdi:solar-power"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy production for today."""
+        if not self.coordinator.data or "energy_usage_today" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_today"]
+        return energy_usage_data.get("today_production")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy production details for today."""
+        if not self.coordinator.data or "energy_usage_today" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_today"]
+        attrs = {}
+        
+        # Add total production if available
+        if energy_usage_data.get("today_total_production") is not None:
+            attrs["total_production"] = energy_usage_data["today_total_production"]
+        
+        # Add frame count
+        if energy_usage_data.get("today_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["today_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+# -----------------------------------------------------------------------------
+# Energy cost and usage sensors for current month
+# -----------------------------------------------------------------------------
+
+
+class PstrykBuyEnergyCostCurrentMonthSensor(PstrykBaseSensor):
+    """Sensor for energy buy cost from current month."""
+
+    _attr_name = "Pstryk Buy Energy Cost – Current Month"
+    _attr_unique_id = "pstryk_energy_cost_buy_current_month"
+    _attr_icon = "mdi:cash-multiple"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy buy cost for current month."""
+        if not self.coordinator.data or "energy_cost_current_month" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_current_month"]
+        return energy_cost_data.get("current_month_cost")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy cost details for current month."""
+        if not self.coordinator.data or "energy_cost_current_month" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_current_month"]
+        attrs = {}
+        
+        # Add total cost if available
+        if energy_cost_data.get("current_month_total_cost") is not None:
+            attrs["total_cost"] = energy_cost_data["current_month_total_cost"]
+        
+        # Add frame count
+        if energy_cost_data.get("current_month_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["current_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyCostCurrentMonthSensor(PstrykBaseSensor):
+    """Sensor for energy sell value from current month."""
+
+    _attr_name = "Pstryk Sell Energy Cost – Current Month"
+    _attr_unique_id = "pstryk_energy_cost_sell_current_month"
+    _attr_icon = "mdi:cash-plus"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy sell value for current month."""
+        if not self.coordinator.data or "energy_cost_current_month" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost_current_month"]
+        return energy_cost_data.get("current_month_sell_value")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy sell details for current month."""
+        if not self.coordinator.data or "energy_cost_current_month" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost_current_month"]
+        attrs = {}
+        
+        # Add frame count
+        if energy_cost_data.get("current_month_frame_count") is not None:
+            attrs["frame_count"] = energy_cost_data["current_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_cost_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykBuyEnergyUsageCurrentMonthSensor(PstrykBaseSensor):
+    """Sensor for energy usage from current month."""
+
+    _attr_name = "Pstryk Buy Energy Usage – Current Month"
+    _attr_unique_id = "pstryk_buy_energy_usage_current_month"
+    _attr_icon = "mdi:flash-auto"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy usage for current month."""
+        if not self.coordinator.data or "energy_usage_current_month" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_current_month"]
+        return energy_usage_data.get("current_month_usage")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy usage details for current month."""
+        if not self.coordinator.data or "energy_usage_current_month" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_current_month"]
+        attrs = {}
+        
+        # Add total usage if available
+        if energy_usage_data.get("current_month_total_usage") is not None:
+            attrs["total_usage"] = energy_usage_data["current_month_total_usage"]
+        
+        # Add frame count
+        if energy_usage_data.get("current_month_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["current_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        return attrs
+
+
+class PstrykSellEnergyProductionCurrentMonthSensor(PstrykBaseSensor):
+    """Sensor for energy production from current month."""
+
+    _attr_name = "Pstryk Sell Energy Production – Current Month"
+    _attr_unique_id = "pstryk_sell_energy_production_current_month"
+    _attr_icon = "mdi:solar-power"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy production for current month."""
+        if not self.coordinator.data or "energy_usage_current_month" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage_current_month"]
+        return energy_usage_data.get("current_month_production")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy production details for current month."""
+        if not self.coordinator.data or "energy_usage_current_month" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage_current_month"]
+        attrs = {}
+        
+        # Add total production if available
+        if energy_usage_data.get("current_month_total_production") is not None:
+            attrs["total_production"] = energy_usage_data["current_month_total_production"]
+        
+        # Add frame count
+        if energy_usage_data.get("current_month_frame_count") is not None:
+            attrs["frame_count"] = energy_usage_data["current_month_frame_count"]
+        
+        # Add period details
+        period_details = energy_usage_data.get("period_details", {})
+        if period_details:
+            if period_details.get("start"):
+                start_dt = dt_util.parse_datetime(period_details["start"])
+                if start_dt:
+                    attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+            
+            if period_details.get("end"):
+                end_dt = dt_util.parse_datetime(period_details["end"])
+                if end_dt:
+                    attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
         
         return attrs

--- a/custom_components/pstryk/sensor.py
+++ b/custom_components/pstryk/sensor.py
@@ -27,6 +27,7 @@ from .const import (
     ATTR_PRICES_FUTURE,
     ATTR_PRICES_TODAY,
     ATTR_PRICES_TOMORROW,
+    ATTR_PREVIOUS_HOUR_ENERGY_COST,
     COORDINATOR,
     DOMAIN,
 )
@@ -50,6 +51,12 @@ async def async_setup_entry(
         # require any extra API calls.
         PstrykBuyNextHourPriceSensor(coordinator),
         PstrykSellNextHourPriceSensor(coordinator),
+        # Energy cost sensors for previous full hour
+        PstrykBuyEnergyCostSensor(coordinator),
+        PstrykSellEnergyCostSensor(coordinator),
+        # Energy usage sensors for previous full hour
+        PstrykBuyEnergyUsageSensor(coordinator),
+        PstrykSellEnergyProductionSensor(coordinator),
     ]
 
     async_add_entities(entities)
@@ -299,3 +306,257 @@ class PstrykSellNextHourPriceSensor(_PstrykNextHourMixin, PstrykBaseSensor):
         return {
             "target_hour": next_hour_start.isoformat(),
         }
+
+
+# -----------------------------------------------------------------------------
+# Energy cost sensor – shows the actual energy cost from the previous full hour
+# based on meter readings and current energy prices
+# -----------------------------------------------------------------------------
+
+
+class PstrykBuyEnergyCostSensor(PstrykBaseSensor):
+    """Sensor for energy buy cost from previous full hour."""
+
+    _attr_name = "Pstryk Buy Energy Cost – Previous Hour"
+    _attr_unique_id = "pstryk_energy_cost_buy_previous_hour"
+    _attr_icon = "mdi:cash-multiple"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy buy cost for the previous full hour."""
+        if not self.coordinator.data or "energy_cost" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost"]
+        return energy_cost_data.get("previous_hour_cost")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy cost details."""
+        if not self.coordinator.data or "energy_cost" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost"]
+        frame_details = energy_cost_data.get("frame_details", {})
+        
+        attrs = {}
+        
+        # Add total cost if available
+        if energy_cost_data.get("total_cost") is not None:
+            attrs["total_cost"] = energy_cost_data["total_cost"]
+        
+        # Add frame timing details
+        if frame_details.get("start"):
+            start_dt = dt_util.parse_datetime(frame_details["start"])
+            if start_dt:
+                attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+        
+        if frame_details.get("end"):
+            end_dt = dt_util.parse_datetime(frame_details["end"])
+            if end_dt:
+                attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        # Add live indicator
+        if frame_details.get("is_live") is not None:
+            attrs["is_live"] = frame_details["is_live"]
+        
+        # Add detailed cost breakdown
+        cost_breakdown = frame_details.get("cost_breakdown", {})
+        if cost_breakdown:
+            attrs.update({
+                "fae_cost": cost_breakdown.get("fae_cost"),
+                "var_dist_cost_net": cost_breakdown.get("var_dist_cost_net"),
+                "fix_dist_cost_net": cost_breakdown.get("fix_dist_cost_net"),
+                "energy_cost_net": cost_breakdown.get("energy_cost_net"),
+                "service_cost_net": cost_breakdown.get("service_cost_net"),
+                "excise": cost_breakdown.get("excise"),
+                "vat": cost_breakdown.get("vat"),
+                "energy_sold_value": cost_breakdown.get("energy_sold_value"),
+                "energy_balance_value": cost_breakdown.get("energy_balance_value"),
+            })
+        
+        return attrs
+    
+class PstrykSellEnergyCostSensor(PstrykBaseSensor):
+    """Sensor for energy sell value from previous full hour."""
+
+    _attr_name = "Pstryk Sell Energy Cost – Previous Hour"
+    _attr_unique_id = "pstryk_energy_cost_sell_previous_hour"
+    _attr_icon = "mdi:cash-plus"
+    _attr_native_unit_of_measurement = "PLN"
+    _attr_device_class = SensorDeviceClass.MONETARY
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy sell value for the previous full hour."""
+        if not self.coordinator.data or "energy_cost" not in self.coordinator.data:
+            return None
+        
+        energy_cost_data = self.coordinator.data["energy_cost"]
+        frame_details = energy_cost_data.get("frame_details", {})
+        cost_breakdown = frame_details.get("cost_breakdown", {})
+        
+        return cost_breakdown.get("energy_sold_value")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy sell details."""
+        if not self.coordinator.data or "energy_cost" not in self.coordinator.data:
+            return {}
+        
+        energy_cost_data = self.coordinator.data["energy_cost"]
+        frame_details = energy_cost_data.get("frame_details", {})
+        
+        attrs = {}
+        
+        # Add frame timing details
+        if frame_details.get("start"):
+            start_dt = dt_util.parse_datetime(frame_details["start"])
+            if start_dt:
+                attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+        
+        if frame_details.get("end"):
+            end_dt = dt_util.parse_datetime(frame_details["end"])
+            if end_dt:
+                attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        # Add live indicator
+        if frame_details.get("is_live") is not None:
+            attrs["is_live"] = frame_details["is_live"]
+        
+        # Add total energy sold value from API root level
+        cost_breakdown = frame_details.get("cost_breakdown", {})
+        if cost_breakdown.get("energy_sold_value") is not None:
+            attrs["energy_sold_value"] = cost_breakdown.get("energy_sold_value")
+        
+        return attrs
+
+
+# -----------------------------------------------------------------------------
+# Energy usage sensors – shows actual energy usage and production from the previous full hour
+# based on meter readings
+# -----------------------------------------------------------------------------
+
+
+class PstrykBuyEnergyUsageSensor(PstrykBaseSensor):
+    """Sensor for energy usage from previous full hour."""
+
+    _attr_name = "Pstryk Buy Energy Usage – Previous Hour"
+    _attr_unique_id = "pstryk_buy_energy_usage_previous_hour"
+    _attr_icon = "mdi:flash-auto"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy usage for the previous full hour."""
+        if not self.coordinator.data or "energy_usage" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage"]
+        return energy_usage_data.get("previous_hour_usage")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy usage details."""
+        if not self.coordinator.data or "energy_usage" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage"]
+        frame_details = energy_usage_data.get("frame_details", {})
+        
+        attrs = {}
+        
+        # Add total usage if available
+        if energy_usage_data.get("total_usage") is not None:
+            attrs["total_usage"] = energy_usage_data["total_usage"]
+        
+        # Add frame timing details
+        if frame_details.get("start"):
+            start_dt = dt_util.parse_datetime(frame_details["start"])
+            if start_dt:
+                attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+        
+        if frame_details.get("end"):
+            end_dt = dt_util.parse_datetime(frame_details["end"])
+            if end_dt:
+                attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        # Add live indicator
+        if frame_details.get("is_live") is not None:
+            attrs["is_live"] = frame_details["is_live"]
+        
+        # Add detailed usage breakdown
+        usage_breakdown = frame_details.get("usage_breakdown", {})
+        if usage_breakdown:
+            attrs.update({
+                "fae_usage": usage_breakdown.get("fae_usage"),
+                "rae": usage_breakdown.get("rae"),
+                "energy_balance": usage_breakdown.get("energy_balance"),
+            })
+        
+        return attrs
+
+
+class PstrykSellEnergyProductionSensor(PstrykBaseSensor):
+    """Sensor for energy production from previous full hour."""
+
+    _attr_name = "Pstryk Sell Energy Production – Previous Hour"
+    _attr_unique_id = "pstryk_sell_energy_production_previous_hour"
+    _attr_icon = "mdi:solar-power"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Energy production for the previous full hour."""
+        if not self.coordinator.data or "energy_usage" not in self.coordinator.data:
+            return None
+        
+        energy_usage_data = self.coordinator.data["energy_usage"]
+        return energy_usage_data.get("previous_hour_production")
+
+    @property
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """Include additional energy production details."""
+        if not self.coordinator.data or "energy_usage" not in self.coordinator.data:
+            return {}
+        
+        energy_usage_data = self.coordinator.data["energy_usage"]
+        frame_details = energy_usage_data.get("frame_details", {})
+        
+        attrs = {}
+        
+        # Add total production if available
+        if energy_usage_data.get("total_production") is not None:
+            attrs["total_production"] = energy_usage_data["total_production"]
+        
+        # Add frame timing details
+        if frame_details.get("start"):
+            start_dt = dt_util.parse_datetime(frame_details["start"])
+            if start_dt:
+                attrs["period_start"] = dt_util.as_local(start_dt).isoformat()
+        
+        if frame_details.get("end"):
+            end_dt = dt_util.parse_datetime(frame_details["end"])
+            if end_dt:
+                attrs["period_end"] = dt_util.as_local(end_dt).isoformat()
+        
+        # Add live indicator
+        if frame_details.get("is_live") is not None:
+            attrs["is_live"] = frame_details["is_live"]
+        
+        # Add energy production value
+        usage_breakdown = frame_details.get("usage_breakdown", {})
+        if usage_breakdown:
+            attrs.update({
+                "fae_usage": usage_breakdown.get("fae_usage"),
+                "rae": usage_breakdown.get("rae"),
+                "energy_balance": usage_breakdown.get("energy_balance"),
+            })
+        
+        return attrs


### PR DESCRIPTION
**✨ New Features**

Added 4 new sensors for the previous full hour:

- Pstryk Buy Energy Cost – Previous Hour - actual energy purchase cost (PLN)
- Pstryk Sell Energy Cost – Previous Hour - energy sell value (PLN)
- Pstryk Buy Energy Usage – Previous Hour - energy consumed from grid (kWh)
- Pstryk Sell Energy Production – Previous Hour - energy produced/fed to grid (kWh)