### PR TITLE
Add ev_smart_charging-compatible price lists and fix monetary state_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ The integration creates the following sensors:
 
 - `sensor.pstryk_buy_price`: Current electricity buying price
 - `sensor.pstryk_sell_price`: Current electricity selling price
+- `sensor.pstryk_buy_price_next_hour`: Buying price for the upcoming hour
+- `sensor.pstryk_sell_price_next_hour`: Selling price for the upcoming hour
 - `binary_sensor.pstryk_buy_cheap_hour`: Indicates if current hour is flagged as cheap for buying
 - `binary_sensor.pstryk_buy_expensive_hour`: Indicates if current hour is flagged as expensive for buying
 - `binary_sensor.pstryk_sell_cheap_hour`: Indicates if current hour is flagged as cheap for selling
 - `binary_sensor.pstryk_sell_expensive_hour`: Indicates if current hour is flagged as expensive for selling
 
-Each price sensor exposes hourly price data via additional attributes:
+Each price sensor exposes hourly price data via additional attributes compatible with [ev_smart_charging](https://github.com/jonasbkarlsson/ev_smart_charging):
 
-- `prices_today` – list of today's prices in the form `[{"time": "ISO", "price": <value>}, ...]`
-- `prices_tomorrow` – list of tomorrow's prices (when available) using the same structure
-- `prices` – combined list of today and tomorrow
+- `prices_today` – list of today's hourly prices: `[{"time": "2025-02-20T00:00:00+01:00", "price": 0.71}, ...]`
+- `prices_tomorrow` – list of tomorrow's hourly prices (same format, empty `[]` when not yet available)
 
 The binary sensors include lists of upcoming cheap or expensive hours.
 
@@ -120,8 +121,7 @@ automation:
 
 To visualise hourly prices you can use the
 [ApexCharts card](https://github.com/RomRider/apexcharts-card) in a Lovelace
-dashboard. The `prices` attribute on each price sensor already contains the
-combined list of today's and tomorrow's prices:
+dashboard:
 
 ```yaml
 type: custom:apexcharts-card
@@ -131,13 +131,15 @@ series:
   - entity: sensor.pstryk_buy_price
     name: Buy Price
     data_generator: |
-      const data = entity.attributes.prices || [];
-      return data.map(i => [i.time, i.price]);
+      const today = entity.attributes.prices_today || [];
+      const tomorrow = entity.attributes.prices_tomorrow || [];
+      return today.concat(tomorrow).map(i => [i.time, i.price]);
   - entity: sensor.pstryk_sell_price
     name: Sell Price
     data_generator: |
-      const data = entity.attributes.prices || [];
-      return data.map(i => [i.time, i.price]);
+      const today = entity.attributes.prices_today || [];
+      const tomorrow = entity.attributes.prices_tomorrow || [];
+      return today.concat(tomorrow).map(i => [i.time, i.price]);
 ```
 
 This configuration will plot all available hourly prices for today and tomorrow.

--- a/custom_components/pstryk/const.py
+++ b/custom_components/pstryk/const.py
@@ -18,12 +18,7 @@ CONF_API_TOKEN = "api_token"
 
 DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
 
-ATTR_NEXT_HOUR_PRICE = "next_hour_price"
-ATTR_PRICES_TODAY = "prices_today"
-ATTR_PRICES_TOMORROW = "prices_tomorrow"
-ATTR_PRICES = "prices"
 ATTR_IS_CHEAP = "is_cheap"
 ATTR_IS_EXPENSIVE = "is_expensive"
 ATTR_CHEAP_HOURS = "cheap_hours"
 ATTR_EXPENSIVE_HOURS = "expensive_hours"
-ATTR_PRICES_FUTURE = "prices_future"

--- a/custom_components/pstryk/manifest.json
+++ b/custom_components/pstryk/manifest.json
@@ -8,5 +8,5 @@
   "codeowners": ["@meal"],
   "requirements": ["aiohttp>=3.8.1"],
   "iot_class": "cloud_polling",
-  "version": "0.2.4"
+  "version": "0.3.0"
 }

--- a/custom_components/pstryk/strings.json
+++ b/custom_components/pstryk/strings.json
@@ -35,18 +35,14 @@
         "name": "Buy price",
         "state_attributes": {
           "prices_today": { "name": "Today's prices" },
-          "prices_tomorrow": { "name": "Tomorrow's prices" },
-          "prices": { "name": "Today and tomorrow" },
-          "next_hour_price": { "name": "Next hour price" }
+          "prices_tomorrow": { "name": "Tomorrow's prices" }
         }
       },
       "sell_price": {
         "name": "Sell price",
         "state_attributes": {
           "prices_today": { "name": "Today's prices" },
-          "prices_tomorrow": { "name": "Tomorrow's prices" },
-          "prices": { "name": "Today and tomorrow" },
-          "next_hour_price": { "name": "Next hour price" }
+          "prices_tomorrow": { "name": "Tomorrow's prices" }
         }
       },
       "buy_price_next_hour": {

--- a/custom_components/pstryk/translations/en.json
+++ b/custom_components/pstryk/translations/en.json
@@ -35,18 +35,14 @@
         "name": "Buy price",
         "state_attributes": {
           "prices_today": { "name": "Today's prices" },
-          "prices_tomorrow": { "name": "Tomorrow's prices" },
-          "prices": { "name": "Today and tomorrow" },
-          "next_hour_price": { "name": "Next hour price" }
+          "prices_tomorrow": { "name": "Tomorrow's prices" }
         }
       },
       "sell_price": {
         "name": "Sell price",
         "state_attributes": {
           "prices_today": { "name": "Today's prices" },
-          "prices_tomorrow": { "name": "Tomorrow's prices" },
-          "prices": { "name": "Today and tomorrow" },
-          "next_hour_price": { "name": "Next hour price" }
+          "prices_tomorrow": { "name": "Tomorrow's prices" }
         }
       },
       "buy_price_next_hour": {


### PR DESCRIPTION
## Summary

- **Add price list attributes** to buy/sell price sensors (`prices_today`, `prices_tomorrow`) in the format required by [ev_smart_charging](https://github.com/jonasbkarlsson/ev_smart_charging/wiki/Price-sensor): `[{"time": "<ISO 8601 with tz>", "price": <float>}, ...]`
- **Always expose both attributes** — empty `[]` when no data available, never missing
- **Fix HA validation error** — remove `state_class=MEASUREMENT` from `PstrykBaseSensor` since `device_class=MONETARY` only permits `state_class=None` or `total`
- **Clean up** unused constants (`ATTR_PRICES`, `ATTR_PRICES_FUTURE`, `ATTR_NEXT_HOUR_PRICE`, etc.) and the `SensorStateClass` import

## Test plan

- [ ] Restart HA and confirm no `state_class` validation errors in logs
- [ ] Verify `prices_today` attribute contains 24 hourly entries with ISO 8601 timestamps
- [ ] Verify `prices_tomorrow` is `[]` when no next-day data, populated when available
- [ ] Confirm ev_smart_charging recognizes the sensor as a valid price source

🤖 Generated with [Claude Code](https://claude.com/claude-code)