### PR TITLE
Add reconfigure step for user-initiated API token update

### DIFF
--- a/custom_components/pstryk/config_flow.py
+++ b/custom_components/pstryk/config_flow.py
@@ -111,6 +111,29 @@ class PstrykConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration (user-initiated token update)."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            valid, error = await validate_api_token(
+                self.hass, user_input[CONF_API_TOKEN]
+            )
+            if valid:
+                return self.async_update_reload_and_abort(
+                    self._get_reconfigure_entry(),
+                    data_updates={CONF_API_TOKEN: user_input[CONF_API_TOKEN]},
+                )
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema({vol.Required(CONF_API_TOKEN): str}),
+            errors=errors,
+        )
+
     async def async_step_reauth(
         self, entry_data: dict[str, Any]
     ) -> ConfigFlowResult:

--- a/custom_components/pstryk/translations/en.json
+++ b/custom_components/pstryk/translations/en.json
@@ -9,6 +9,13 @@
           "name": "Name"
         }
       },
+      "reconfigure": {
+        "title": "Reconfigure Pstryk.pl",
+        "description": "Update your Pstryk.pl API token.",
+        "data": {
+          "api_token": "API Token"
+        }
+      },
       "reauth_confirm": {
         "title": "Re-authenticate with Pstryk.pl",
         "description": "Your API token is no longer valid. Please enter a new token.",
@@ -26,7 +33,8 @@
     },
     "abort": {
       "already_configured": "Pstryk.pl is already configured.",
-      "reauth_successful": "Re-authentication was successful."
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "Reconfiguration was successful."
     }
   },
   "entity": {


### PR DESCRIPTION
## Summary

- Adds `async_step_reconfigure` to the config flow so users can update their API token without deleting and re-adding the integration
- Adds translation strings for the new reconfigure step and its success abort message

## Test plan

- [ ] Install the integration with a valid API token
- [ ] Go to Settings → Devices & Services → Pstryk → three-dot menu → Reconfigure
- [ ] Verify the reconfigure form appears and accepts a new token
- [ ] Verify an invalid token shows an appropriate error
- [ ] Verify a valid new token saves and reloads the integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)