### PR TITLE
Introduce prices attribute that merges prices_today and prices_tomorrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+.TemporaryItems
+.fseventsd
+
+# Python bytecode / caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Packaging / build artifacts
+build/
+dist/
+*.egg-info/
+*.egg
+MANIFEST
+pip-wheel-metadata/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+.hypothesis/
+
+# Type checkers / linters
+.mypy_cache/
+.pytype/
+.ruff_cache/
+
+# Environments / tooling
+.tox/
+.nox/
+.cache/
+
+# IDE / editor
+.vscode/
+.idea/
+*.iml
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Logs
+*.log

--- a/custom_components/pstryk/sensor.py
+++ b/custom_components/pstryk/sensor.py
@@ -78,7 +78,7 @@ class _PstrykPriceSensor(PstrykBaseSensor):
         [{"time": "<ISO 8601 with tz>", "price": <float>}, ...]
     """
 
-    _unrecorded_attributes = frozenset({"prices_today", "prices_tomorrow"})
+    _unrecorded_attributes = frozenset({"prices", "prices_today", "prices_tomorrow"})
 
     # Must be set by subclass ("buy" | "sell")
     _price_key: str = "buy"
@@ -105,7 +105,7 @@ class _PstrykPriceSensor(PstrykBaseSensor):
         """Expose price lists compatible with ev_smart_charging."""
         branch = self._price_branch()
         if branch is None:
-            return {"prices_today": [], "prices_tomorrow": []}
+            return {"prices_today": [], "prices_tomorrow": [], "prices": []}
 
         now = dt_util.now()
         today_date = now.date()
@@ -137,10 +137,12 @@ class _PstrykPriceSensor(PstrykBaseSensor):
 
         prices_today.sort(key=lambda x: x["time"])
         prices_tomorrow.sort(key=lambda x: x["time"])
+        combined_prices = sorted(prices_today + prices_tomorrow, key=lambda x: x["time"])
 
         attrs: dict[str, Any] = {
             "prices_today": prices_today,
             "prices_tomorrow": prices_tomorrow,
+            "prices": combined_prices,
         }
 
         if branch.get(ATTR_IS_CHEAP) is not None:

--- a/custom_components/pstryk/strings.json
+++ b/custom_components/pstryk/strings.json
@@ -34,6 +34,7 @@
       "buy_price": {
         "name": "Buy price",
         "state_attributes": {
+          "prices": { "name": "Prices" },
           "prices_today": { "name": "Today's prices" },
           "prices_tomorrow": { "name": "Tomorrow's prices" }
         }
@@ -41,6 +42,7 @@
       "sell_price": {
         "name": "Sell price",
         "state_attributes": {
+          "prices": { "name": "Prices" },
           "prices_today": { "name": "Today's prices" },
           "prices_tomorrow": { "name": "Tomorrow's prices" }
         }

--- a/custom_components/pstryk/translations/en.json
+++ b/custom_components/pstryk/translations/en.json
@@ -34,6 +34,7 @@
       "buy_price": {
         "name": "Buy price",
         "state_attributes": {
+          "prices": { "name": "Prices" },
           "prices_today": { "name": "Today's prices" },
           "prices_tomorrow": { "name": "Tomorrow's prices" }
         }
@@ -41,6 +42,7 @@
       "sell_price": {
         "name": "Sell price",
         "state_attributes": {
+          "prices": { "name": "Prices" },
           "prices_today": { "name": "Today's prices" },
           "prices_tomorrow": { "name": "Tomorrow's prices" }
         }


### PR DESCRIPTION
There are other integrations that consume only `prices` attribute with whole pricetable for today and tomorrow.
`prices` was available in 0.2.x family and it disappeared somehow.