### PR TITLE
Fix: empty prices_tomorrow returns empty list instead of 0

### DIFF
--- a/custom_components/pstryk/sensor.py
+++ b/custom_components/pstryk/sensor.py
@@ -111,6 +111,8 @@ class _PstrykPriceSensor(PstrykBaseSensor):
         today_date = now.date()
         tomorrow_date = today_date + timedelta(days=1)
         prices = branch.get("prices", [])
+        if not isinstance(prices, list):
+            prices = []
 
         prices_today: list[dict[str, Any]] = []
         prices_tomorrow: list[dict[str, Any]] = []


### PR DESCRIPTION
According to the documentation prices_tomorrow must be a list when empty

- `prices_tomorrow` – list of tomorrow's hourly prices (same format, empty `[]` when not yet available)